### PR TITLE
✨ Add MbedOS

### DIFF
--- a/mbed_project/_internal/project_data.py
+++ b/mbed_project/_internal/project_data.py
@@ -112,7 +112,7 @@ class MbedOS:
     targets_json_file: Path
 
     @classmethod
-    def from_existing(cls, root_path: Path):
+    def from_existing(cls, root_path: Path) -> "MbedOS":
         targets_json_file = root_path / "targets.json"
 
         if not targets_json_file.exists():

--- a/mbed_project/_internal/project_data.py
+++ b/mbed_project/_internal/project_data.py
@@ -97,3 +97,24 @@ class MbedProgramData:
             raise ValueError(f"An Mbed program does not exist at {root_path}")
 
         return cls(config_file=config, mbed_file=mbed_file)
+
+
+@dataclass
+class MbedOS:
+    """Metadata associated with a copy of MbedOS.
+
+    This object holds information about MbedOS used by MbedProgram.
+
+    Attributes:
+        targets_json_file: Path to a targets.json file, which contains target data specific to MbedOS revision.
+    """
+
+    targets_json_file: Path
+
+    @classmethod
+    def from_existing(cls, root_path: Path):
+        targets_json_file = root_path / "targets.json"
+
+        if not targets_json_file.exists():
+            raise ValueError("This MbedOS copy does not contain a targets.json file.")
+        return cls(targets_json_file=targets_json_file)

--- a/mbed_project/_internal/project_data.py
+++ b/mbed_project/_internal/project_data.py
@@ -114,7 +114,7 @@ class MbedOS:
     @classmethod
     def from_existing(cls, root_path: Path) -> "MbedOS":
         """Create MbedOS from a directory constaining an existing MbedOS installation."""
-        targets_json_file = root_path / "targets.json"
+        targets_json_file = root_path / "targets" / "targets.json"
 
         if not targets_json_file.exists():
             raise ValueError("This MbedOS copy does not contain a targets.json file.")

--- a/mbed_project/_internal/project_data.py
+++ b/mbed_project/_internal/project_data.py
@@ -113,6 +113,7 @@ class MbedOS:
 
     @classmethod
     def from_existing(cls, root_path: Path) -> "MbedOS":
+        """Create MbedOS from a directory constaining an existing MbedOS installation."""
         targets_json_file = root_path / "targets.json"
 
         if not targets_json_file.exists():

--- a/mbed_project/mbed_program.py
+++ b/mbed_project/mbed_program.py
@@ -31,7 +31,7 @@ class MbedProgram:
         Args:
             repo: The program's associated git repository.
             program_data: An instance of `MbedProgramData` containing metadata about the program.
-            mbed_os: An instance of `MbedOS` containing metadata about MbedOS copy used.
+            mbed_os: An instance of `MbedOS` containing metadata about the Mbed OS copy used.
         """
         self.repo = repo
         self.metadata = program_data

--- a/mbed_project/mbed_program.py
+++ b/mbed_project/mbed_program.py
@@ -6,11 +6,12 @@
 import logging
 
 from pathlib import Path
+from typing import Optional
 
 import git
 
 from mbed_project.exceptions import VersionControlError, ProgramNotFound, ExistingProgram
-from mbed_project._internal.project_data import MbedProgramData
+from mbed_project._internal.project_data import MbedProgramData, MbedOS
 
 logger = logging.getLogger(__name__)
 
@@ -24,15 +25,17 @@ class MbedProgram:
     `MbedProgram` provides classmethods to cope with different initialisation scenarios.
     """
 
-    def __init__(self, repo: git.Repo, program_data: MbedProgramData) -> None:
+    def __init__(self, repo: git.Repo, program_data: MbedProgramData, mbed_os: Optional[MbedOS]) -> None:
         """Initialise the program attributes.
 
         Args:
             repo: The program's associated git repository.
             program_data: An instance of `MbedProgramData` containing metadata about the program.
+            mbed_os: An instance of `MbedOS` containing metadata about MbedOS copy used.
         """
         self.repo = repo
         self.metadata = program_data
+        self.mbed_os = mbed_os
 
     @classmethod
     def from_remote_url(cls, url: str, dst_path: Path) -> "MbedProgram":
@@ -58,7 +61,8 @@ class MbedProgram:
             raise VersionControlError(f"Failed to clone from the remote URL. Error from VCS: {e.stderr}.")
 
         program = MbedProgramData.from_existing(dst_path)
-        return cls(repo, program)
+        mbed_os = None
+        return cls(repo, program, mbed_os)
 
     @classmethod
     def from_new_local_directory(cls, dir_path: Path) -> "MbedProgram":
@@ -83,7 +87,8 @@ class MbedProgram:
         program_data = MbedProgramData.from_new(dir_path)
         logger.info(f"Creating git repository for the Mbed program {dir_path}")
         repo = git.Repo.init(str(dir_path))
-        return cls(repo, program_data)
+        mbed_os = None
+        return cls(repo, program_data, mbed_os)
 
     @classmethod
     def from_existing_local_program_directory(cls, dir_path: Path) -> "MbedProgram":
@@ -99,7 +104,8 @@ class MbedProgram:
         logger.info(f"Found existing Mbed program at path '{program_root}'")
         repo = git.Repo(str(program_root))
         program = MbedProgramData.from_existing(program_root)
-        return cls(repo, program)
+        mbed_os = MbedOS.from_existing(program_root)
+        return cls(repo, program, mbed_os)
 
 
 def _tree_contains_program(path: Path) -> bool:

--- a/news/20200402.feature
+++ b/news/20200402.feature
@@ -1,0 +1,1 @@
+Add MbedOS metadata class

--- a/tests/_internal/test_mbed_program.py
+++ b/tests/_internal/test_mbed_program.py
@@ -12,8 +12,8 @@ from pyfakefs.fake_filesystem_unittest import patchfs
 
 from mbed_project.mbed_program import MbedProgram, _find_program_root
 from mbed_project.mbed_program import ExistingProgram, ProgramNotFound, VersionControlError
-from mbed_project._internal.project_data import MbedProgramData
-from tests.factories import make_mbed_program_files
+from mbed_project._internal.project_data import MbedProgramData, MbedOS
+from tests.factories import make_mbed_program_files, make_mbed_os_files
 
 
 class TestInitialiseProgram(TestCase):
@@ -87,10 +87,12 @@ class TestInitialiseProgram(TestCase):
     def test_from_existing_returns_valid_program(self, mock_repo, fs):
         fs_root = pathlib.Path("/foo")
         make_mbed_program_files(fs_root, fs)
+        make_mbed_os_files(fs_root, fs)
 
         program = MbedProgram.from_existing_local_program_directory(fs_root)
 
         self.assertEqual(program.metadata, MbedProgramData.from_existing(fs_root))
+        self.assertEqual(program.mbed_os, MbedOS.from_existing(fs_root))
         self.assertEqual(program.repo, mock_repo.return_value)
         mock_repo.assert_called_once_with(str(fs_root))
 

--- a/tests/_internal/test_project_data.py
+++ b/tests/_internal/test_project_data.py
@@ -25,7 +25,7 @@ class TestMbedProgramData(TestCase):
     @patchfs
     def test_from_new_returns_valid_program(self, fs):
         root = pathlib.Path("foo")
-        fs.create_dir(str(root))
+        fs.create_dir(root)
 
         program = MbedProgramData.from_new(root)
 
@@ -34,7 +34,7 @@ class TestMbedProgramData(TestCase):
     @patchfs
     def test_from_existing_raises_if_program_doesnt_exist(self, fs):
         root = pathlib.Path("foo")
-        fs.create_dir(str(root))
+        fs.create_dir(root)
 
         with self.assertRaises(ValueError):
             MbedProgramData.from_existing(root)

--- a/tests/_internal/test_project_data.py
+++ b/tests/_internal/test_project_data.py
@@ -81,7 +81,7 @@ class TestMbedOS(TestCase):
 
         mbed_os = MbedOS.from_existing(root_path)
 
-        self.assertEqual(mbed_os.targets_json_file, root_path / "targets.json")
+        self.assertEqual(mbed_os.targets_json_file, root_path / "targets" / "targets.json")
 
     @patchfs
     def test_raises_if_files_missing(self, fs):

--- a/tests/_internal/test_project_data.py
+++ b/tests/_internal/test_project_data.py
@@ -9,8 +9,8 @@ from unittest import TestCase
 
 from pyfakefs.fake_filesystem_unittest import patchfs
 
-from mbed_project._internal.project_data import MbedProgramData
-from tests.factories import make_mbed_lib_reference, make_mbed_program_files
+from mbed_project._internal.project_data import MbedProgramData, MbedOS
+from tests.factories import make_mbed_lib_reference, make_mbed_program_files, make_mbed_os_files
 
 
 class TestMbedProgramData(TestCase):
@@ -71,3 +71,22 @@ class TestMbedLibReference(TestCase):
         lib = make_mbed_lib_reference(root, fs, ref_url=url)
 
         self.assertEqual(lib.get_git_reference(), url)
+
+
+class TestMbedOS(TestCase):
+    @patchfs
+    def test_from_existing_finds_existing_mbed_os_data(self, fs):
+        root_path = pathlib.Path("my-version-of-mbed-os")
+        make_mbed_os_files(root_path, fs)
+
+        mbed_os = MbedOS.from_existing(root_path)
+
+        self.assertEqual(mbed_os.targets_json_file, root_path / "targets.json")
+
+    @patchfs
+    def test_raises_if_files_missing(self, fs):
+        root_path = pathlib.Path("my-version-of-mbed-os")
+        fs.create_dir(root_path)
+
+        with self.assertRaises(ValueError):
+            MbedOS.from_existing(root_path)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -23,3 +23,8 @@ def make_mbed_lib_reference(root, fs, resolved=False, ref_url=None):
         ref_file.write_text(ref_url)
 
     return MbedLibReference(reference_file=ref_file, source_code_path=source_dir)
+
+
+def make_mbed_os_files(root, fs):
+    fs.create_dir(root)
+    fs.create_file(root / "targets.json")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,18 +6,18 @@ from mbed_project._internal.project_data import MbedLibReference
 
 
 def make_mbed_program_files(root, fs, config_file_name="mbed_app.json"):
-    fs.create_dir(str(root))
-    fs.create_file(str(root / ".mbed"))
-    fs.create_file(str(root / config_file_name))
+    fs.create_dir(root)
+    fs.create_file(root / ".mbed")
+    fs.create_file(root / config_file_name)
 
 
 def make_mbed_lib_reference(root, fs, resolved=False, ref_url=None):
     ref_file = root / "mylib.lib"
     source_dir = ref_file.with_suffix("")
-    fs.create_dir(str(root))
-    fs.create_file(str(ref_file))
+    fs.create_dir(root)
+    fs.create_file(ref_file)
     if resolved:
-        fs.create_dir(str(source_dir))
+        fs.create_dir(source_dir)
 
     if ref_url is not None:
         ref_file.write_text(ref_url)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -30,4 +30,4 @@ def make_mbed_lib_reference(root, fs, resolved=False, ref_url=None):
 def make_mbed_os_files(root, fs):
     if not root.exists():
         fs.create_dir(root)
-    fs.create_file(root / "targets.json")
+    fs.create_file(root / "targets" / "targets.json")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,7 +6,8 @@ from mbed_project._internal.project_data import MbedLibReference
 
 
 def make_mbed_program_files(root, fs, config_file_name="mbed_app.json"):
-    fs.create_dir(root)
+    if not root.exists():
+        fs.create_dir(root)
     fs.create_file(root / ".mbed")
     fs.create_file(root / config_file_name)
 
@@ -14,7 +15,8 @@ def make_mbed_program_files(root, fs, config_file_name="mbed_app.json"):
 def make_mbed_lib_reference(root, fs, resolved=False, ref_url=None):
     ref_file = root / "mylib.lib"
     source_dir = ref_file.with_suffix("")
-    fs.create_dir(root)
+    if not root.exists():
+        fs.create_dir(root)
     fs.create_file(ref_file)
     if resolved:
         fs.create_dir(source_dir)
@@ -26,5 +28,6 @@ def make_mbed_lib_reference(root, fs, resolved=False, ref_url=None):
 
 
 def make_mbed_os_files(root, fs):
-    fs.create_dir(root)
+    if not root.exists():
+        fs.create_dir(root)
     fs.create_file(root / "targets.json")


### PR DESCRIPTION
### Description

Adds `MbedOS` data class for existing programs - purely for `mbed-targets` sake.
The idea is that `mbed_targets.get_build_attributes_by_*` will be given a path to root of an Mbed project and pass that through to `mbed_project.MbedProgram` in order to determine the location of `targets.json` file. Phew. 😅

I'm not sure about the resolution algorithm for `mbed-os` for cloned/newly initialised programs. Also, it wasn't really my intention to add that functionality. (Convince me otherwise!)

I could use advice on how and where to handle exceptions that stem from the fact that `MbedOS` can't be built. (`targets.json` is not available).


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
