### PR TITLE
Add a version specifier to the Python dependancies for Mbed packages

### DIFF
--- a/news/20200422.misc
+++ b/news/20200422.misc
@@ -1,0 +1,1 @@
+Add a version specifier to the Python dependancies for Mbed packages

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "python-dotenv",
         "Click==7.0",
         "dataclasses; python_version<'3.7'",
-        "mbed-tools-lib",
+        "mbed-tools-lib~=1.2",
         "git-python",
         "tqdm",
     ],


### PR DESCRIPTION
### Description

So that we can make future breaking changes to Mbed packages relied on by `mbed-tools`, a version specifier is set for each Mbed package. This simplifies development, allowing internal interfaces to be changed while ensuring that new tools will not be installed if the are not compatible.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [x]  Additional tests are not required for this change (e.g. documentation update).
