### PR TITLE
📝 Reduce usage of shields.io badges so they render correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-# Mbed Project
+# Package: mbed-project
 
-![Package](https://img.shields.io/badge/Package-mbed--project-lightgrey)
 [![Documentation](https://img.shields.io/badge/Documentation-GitHub_Pages-blue)](https://armmbed.github.io/mbed-project)
-[![PyPI](https://img.shields.io/pypi/v/mbed-project)](https://pypi.org/project/mbed-project/)
-[![PyPI - Status](https://img.shields.io/pypi/status/mbed-project)](https://pypi.org/project/mbed-project/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mbed-project)](https://pypi.org/project/mbed-project/)
+[![PyPI version](https://badge.fury.io/py/mbed-project.svg)](https://badge.fury.io/py/mbed-project)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ARMmbed/mbed-project/blob/master/LICENSE)
 
 [![Build Status](https://dev.azure.com/mbed-tools/mbed-project/_apis/build/status/Build%20and%20Release?branchName=master&stageName=CI%20Checkpoint)](https://dev.azure.com/mbed-tools/mbed-project/_build/latest?definitionId=14&branchName=master)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Package: mbed-project
+# Package: Mbed Project
 
-[![Documentation](https://img.shields.io/badge/Documentation-GitHub_Pages-blue)](https://armmbed.github.io/mbed-project)
-[![PyPI version](https://badge.fury.io/py/mbed-project.svg)](https://badge.fury.io/py/mbed-project)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/ARMmbed/mbed-project/blob/master/LICENSE)
+![Package](https://badgen.net/badge/Package/mbed-project/grey)
+[![Documentation](https://badgen.net/badge/Documentation/GitHub%20Pages/blue?icon=github)](https://armmbed.github.io/mbed-project)
+[![PyPI](https://badgen.net/pypi/v/mbed-project)](https://pypi.org/project/mbed-project/)
+[![PyPI - Status](https://img.shields.io/pypi/status/mbed-project)](https://pypi.org/project/mbed-project/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mbed-project)](https://pypi.org/project/mbed-project/)
+[![License](https://badgen.net/pypi/license/mbed-project)](https://github.com/ARMmbed/mbed-project/blob/master/LICENSE)
 
 [![Build Status](https://dev.azure.com/mbed-tools/mbed-project/_apis/build/status/Build%20and%20Release?branchName=master&stageName=CI%20Checkpoint)](https://dev.azure.com/mbed-tools/mbed-project/_build/latest?definitionId=14&branchName=master)
 [![Test Coverage](https://codecov.io/gh/ARMmbed/mbed-project/branch/master/graph/badge.svg)](https://codecov.io/gh/ARMmbed/mbed-project)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Package: Mbed Project
+# Mbed Project
 
 ![Package](https://badgen.net/badge/Package/mbed-project/grey)
 [![Documentation](https://badgen.net/badge/Documentation/GitHub%20Pages/blue?icon=github)](https://armmbed.github.io/mbed-project)

--- a/news/20200423.misc
+++ b/news/20200423.misc
@@ -1,1 +1,1 @@
-Remove usage of shields.io badges with PyPI
+Reduce usage of shields.io badges so they render correctly

--- a/news/20200423.misc
+++ b/news/20200423.misc
@@ -1,0 +1,1 @@
+Remove usage of shields.io badges with PyPI


### PR DESCRIPTION
### Description

These badges for PyPI rarely load using `shields.io` so instead use a different badge from `fury.io` for the version and remove all other badges.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
